### PR TITLE
Optimise usability of `Eyeson::shutdown` function

### DIFF
--- a/src/Eyeson.php
+++ b/src/Eyeson.php
@@ -44,7 +44,11 @@ class Eyeson {
    * Force shutdown a running meeting.
    **/
   public function shutdown($room) {
-    return (new Room($this->api, $room->getId()))->destroy();
+    if(is_string($room)) {
+      return (new Room($this->api, $room))->destroy();
+    } else {
+      return (new Room($this->api, $room->getId()))->destroy();
+    }
   }
 
   /**


### PR DESCRIPTION
Check if `$room`  is a string, and if so use it like that. When there are two PHP requests involved (one the start and one to end the conference), it is easier to pass the room id (a string) to the `shutdown` function.